### PR TITLE
Close logger's internal timer to avoid busy event loop

### DIFF
--- a/lib/logzio-nodejs.js
+++ b/lib/logzio-nodejs.js
@@ -21,6 +21,8 @@ var LogzioLogger = function (options) {
     this.bufferSize = options.bufferSize || 100;
     this.debug = options.debug || false;
     this.numberOfRetries = options.numberOfRetries || 3;
+    this.timer = null;
+    this.closed = false;
 
     /*
       Callback method executed on each bulk of messages sent to logzio.
@@ -69,7 +71,7 @@ LogzioLogger.prototype._timerSend = function() {
         this._popMsgsAndSend();
     }
     var mythis = this;
-    setTimeout(
+    this.timer = setTimeout(
         function() {
             mythis._timerSend();
         },
@@ -77,7 +79,24 @@ LogzioLogger.prototype._timerSend = function() {
     );
 };
 
+LogzioLogger.prototype.close = function () {
+    // clearing the timer allows the node event loop to quit when needed
+    clearTimeout(this.timer);
+
+    // send pending messages, if any
+    if (this.messages.length > 0) {
+        this._debug("Closing, purging messages.");
+        this._popMsgsAndSend();
+    }
+
+    // no more logging allowed
+    this.closed = true;
+};
+
 LogzioLogger.prototype.log = function(msg) {
+    if (this.closed === true) {
+        throw new Error('Logging into a logger that has been closed!');
+    }
     if (typeof msg === 'string') {
         msg = {message: msg};
         if (this.type) msg.type = this.type;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "json-stringify-safe": "5.0.x",
     "lodash": "^3.10.1",
-    "request": "2.49.x"
+    "request": "2.68.0"
   },
   "devDependencies": {
     "assert": "^1.3.0",

--- a/test/test-logger.js
+++ b/test/test-logger.js
@@ -42,6 +42,7 @@ describe('logger', function() {
             assert(logger._createBulk.getCall(0).args[0][0].message == logMsg);
 
             logger._createBulk.restore();
+            logger.close();
         });
 
         it('sends log as a string with extra fields', function(done) {
@@ -61,6 +62,7 @@ describe('logger', function() {
             assert(logger._createBulk.getCall(0).args[0][0].extraField2 == 'val2');
 
             logger._createBulk.restore();
+            logger.close();
         });
 
         it('sends log as an object', function (done) {
@@ -72,6 +74,7 @@ describe('logger', function() {
             assert(logger._createBulk.getCall(0).args[0][0].message == logMsg.message);
 
             logger._createBulk.restore();
+            logger.close();
         });
 
         it('sends log as an object with extra fields', function(done) {
@@ -91,6 +94,7 @@ describe('logger', function() {
             assert(logger._createBulk.getCall(0).args[0][0].extraField2 == 'val2');
 
             logger._createBulk.restore();
+            logger.close();
         });
     });
 
@@ -112,6 +116,7 @@ describe('logger', function() {
             logger.log({messge:"hello there from test", testid:2});
             logger.log({messge:"hello there from test2", testid:2});
             logger.log({messge:"hello there from test3", testid:2});
+            logger.close();
         });
 
         it('Send multiple bulks', function (done) {
@@ -129,9 +134,33 @@ describe('logger', function() {
             logger.log({messge:"hello there from test", testid:4});
             logger.log({messge:"hello there from test2", testid:4});
             logger.log({messge:"hello there from test3", testid:4});
+            logger.close();
+        });
+    });
+
+    describe('#log-closing', function () {
+        before(function(done){
+            sinon
+                .stub(request, 'post')
+                .yields(null, {statusCode: 200} , "");
+            done();
         });
 
+        after(function(done){
+            request.post.restore();
+            done();
+        });
 
+        it('Don\'t allow logs after closing', function (done) {
+            var logger = createLogger({bufferSize:1});
+            logger.close();
+            try {
+              logger.log({messge:"hello there from test"});
+              done("Expected an error when logging into a closed log!");
+            } catch (ex) {
+              done();
+            }
+        });
     });
 
     describe('#timers', function () {
@@ -166,7 +195,9 @@ describe('logger', function() {
                 for (var i = 0; i < 100; i++) {
                     logger.log({messge:"hello there from test", testid:6});
                 }
+                logger.close();
             }, 11000)
+
         });
 
     });
@@ -214,6 +245,7 @@ describe('logger', function() {
             var logger = createLogger({bufferSize:1, sendIntervalMs:50000, timeout: 1000});
 
             logger.log({messge:"hello there from test", testid:5});
+            logger.close();
 
             setTimeout(function(){
                 if (!errorAndThenSuccessScope.isDone()) {
@@ -254,6 +286,7 @@ describe('logger', function() {
             logger.log({messge:"hello there from test", testid:2});
             logger.log({messge:"hello there from test2", testid:2});
             logger.log({messge:"hello there from test3", testid:2});
+            logger.close();
         });
     });
 


### PR DESCRIPTION
Adding the `close` method to clear `_sendTimer` and purge any pending logs. This frees up the event loop for test scenarios where the logger would prevent the test from ever completing.

@gillyb this should later propagate into winston-logzio, I'll issue another PR once this is approved.

Similar to @barakhaim 's pull request, with tests and preventing additional logs into closed logger.
