### PR TITLE
Update request to 2.75.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "json-stringify-safe": "5.0.x",
     "lodash": "^3.10.1",
-    "request": "2.68.0"
+    "request": "2.75.0"
   },
   "devDependencies": {
     "assert": "^1.3.0",


### PR DESCRIPTION
Hello !

This huge PR :-) is motivated by the deprecation warning I get in my logs each time I run `npm install`.

```
npm WARN deprecated tough-cookie@2.2.2: ReDoS vulnerability parsing Set-Cookie https://nodesecurity.io/advisories/130
```

Apparently, tough-cookie is a dependency of request so i took the opportunity to upgrade to the latest version.
