### PR TITLE
Record timestamp at log event time

### DIFF
--- a/lib/logzio-nodejs.js
+++ b/lib/logzio-nodejs.js
@@ -151,9 +151,11 @@ LogzioLogger.prototype.log = function(msg) {
     msg = _assign(msg, this.extraFields);
     msg.type = this.type;
 
+    var now = (new Date()).toISOString();
+    msg['@timestamp'] = now;
+
     if (this.addTimestampWithNanoSecs) {
         var time = process.hrtime();
-        var now = (new Date()).toISOString();
         msg['@timestamp_nano'] = [now, time[0].toString(), time[1].toString()].join('-');
     }
 


### PR DESCRIPTION
As it stands, the *timestamp* field was determined server-side.  So, if you bulk up 100 events over a period of 10 seconds and the bulk submission kicks in, all 100 events will have the exact same timestamp even though they were really spread out over a 10 second period of time.

This simple change records the timestamp when the log event occurred from a client perspective to resolve that situation.

When looking at the Logz.io Java logging libraries, the timestamp field was also captured client side and sent to the server, so this change appears to be in-line with the other libraries.