### PR TITLE
Update moment package to fix ReDOS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "json-stringify-safe": "5.0.x",
     "lodash.assign": "4.2.0",
-    "moment": "^2.18.1",
+    "moment": "^2.19.3",
     "request": "2.75.0"
   },
   "devDependencies": {


### PR DESCRIPTION
moment < 2.19.3 has a ReDos vulnerability and they promptly fixed