### PR TITLE
padding nanosec-timestamp with zeroes

### DIFF
--- a/lib/logzio-nodejs.d.ts
+++ b/lib/logzio-nodejs.d.ts
@@ -23,6 +23,7 @@ interface ILogzioLogger extends ILoggerOptions{
     log(msg: string): void;
     close(): void;
     sendAndClose(callback: (error: Error, bulk: object) => void): void;
+    padNumberWithZeros(nanosec_timestamp: number);
 }
 
 export function createLogger(options: ILoggerOptions): ILogzioLogger;

--- a/lib/logzio-nodejs.d.ts
+++ b/lib/logzio-nodejs.d.ts
@@ -23,7 +23,6 @@ interface ILogzioLogger extends ILoggerOptions{
     log(msg: string): void;
     close(): void;
     sendAndClose(callback: (error: Error, bulk: object) => void): void;
-    padNumberWithZeros(nanosec_timestamp: number);
 }
 
 export function createLogger(options: ILoggerOptions): ILogzioLogger;

--- a/lib/logzio-nodejs.js
+++ b/lib/logzio-nodejs.js
@@ -3,6 +3,7 @@ const stringifySafe = require('json-stringify-safe');
 const assign = require('lodash.assign');
 const dgram = require('dgram');
 const zlib = require('zlib');
+const nanoSecDigits = 9;
 
 exports.version = require('../package.json').version;
 
@@ -184,7 +185,7 @@ class LogzioLogger {
 
         if (this.addTimestampWithNanoSecs) {
             const time = process.hrtime();
-            msg['@timestamp_nano'] = msg['@timestamp_nano'] || [now, time[0].toString(), time[1].toString()].join('-');
+            msg['@timestamp_nano'] = msg['@timestamp_nano'] || [now, this._padNumberWithZeros(time[1].toString())].join('-');
         }
     }
 
@@ -303,6 +304,9 @@ class LogzioLogger {
 
                 return this.callback(err, bulk);
             });
+    }
+    _padNumberWithZeros(nano_sec){
+        return Array(Math.max(nanoSecDigits - String(nano_sec).length + 1, 0)).join('0') + nano_sec;
     }
 }
 

--- a/lib/logzio-nodejs.js
+++ b/lib/logzio-nodejs.js
@@ -185,7 +185,7 @@ class LogzioLogger {
 
         if (this.addTimestampWithNanoSecs) {
             const time = process.hrtime();
-            msg['@timestamp_nano'] = msg['@timestamp_nano'] || [now, this.padNumberWithZeros(time[1].toString())].join('-');
+            msg['@timestamp_nano'] = msg['@timestamp_nano'] || [now, this._padNumberWithZeros(time[1].toString())].join('-');
         }
     }
 
@@ -306,7 +306,7 @@ class LogzioLogger {
             });
     }   
     
-    padNumberWithZeros(nanosec_timestamp){
+    _padNumberWithZeros(nanosec_timestamp){
         return String(nanosec_timestamp).padStart(nanoSecDigits ,'0');
     }
 }

--- a/lib/logzio-nodejs.js
+++ b/lib/logzio-nodejs.js
@@ -185,7 +185,7 @@ class LogzioLogger {
 
         if (this.addTimestampWithNanoSecs) {
             const time = process.hrtime();
-            msg['@timestamp_nano'] = msg['@timestamp_nano'] || [now, this._padNumberWithZeros(time[1].toString())].join('-');
+            msg['@timestamp_nano'] = msg['@timestamp_nano'] || [now, time[1].toString().padEnd()].join('-');
         }
     }
 
@@ -304,9 +304,10 @@ class LogzioLogger {
 
                 return this.callback(err, bulk);
             });
-    }
-    _padNumberWithZeros(nano_sec){
-        return Array(Math.max(nanoSecDigits - String(nano_sec).length + 1, 0)).join('0') + nano_sec;
+    }   
+    
+    padNumberWithZeros(nanosec_timestamp){
+        return String(nanosec_timestamp).padStart(nanoSecDigits ,'0');
     }
 }
 
@@ -319,5 +320,5 @@ const createLogger = (options) => {
 
 module.exports = {
     jsonToString,
-    createLogger,
+    createLogger
 };

--- a/lib/logzio-nodejs.js
+++ b/lib/logzio-nodejs.js
@@ -185,7 +185,7 @@ class LogzioLogger {
 
         if (this.addTimestampWithNanoSecs) {
             const time = process.hrtime();
-            msg['@timestamp_nano'] = msg['@timestamp_nano'] || [now, time[1].toString().padEnd()].join('-');
+            msg['@timestamp_nano'] = msg['@timestamp_nano'] || [now, this.padNumberWithZeros(time[1].toString())].join('-');
         }
     }
 

--- a/lib/logzio-nodejs.js
+++ b/lib/logzio-nodejs.js
@@ -185,7 +185,7 @@ class LogzioLogger {
 
         if (this.addTimestampWithNanoSecs) {
             const time = process.hrtime();
-            msg['@timestamp_nano'] = msg['@timestamp_nano'] || [now, this._padNumberWithZeros(time[1].toString())].join('-');
+            msg['@timestamp_nano'] = msg['@timestamp_nano'] || [now, time[1].toString().padStart(nanoSecDigits ,'0')].join('-');
         }
     }
 
@@ -305,10 +305,6 @@ class LogzioLogger {
                 return this.callback(err, bulk);
             });
     }   
-    
-    _padNumberWithZeros(nanosec_timestamp){
-        return String(nanosec_timestamp).padStart(nanoSecDigits ,'0');
-    }
 }
 
 const createLogger = (options) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2922,6 +2922,11 @@
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
     },
+    "hrtimemock": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hrtimemock/-/hrtimemock-2.0.0.tgz",
+      "integrity": "sha1-nAUX47e/WLjsCqpapKwlDs+uizg="
+    },
     "html-encoding-sniffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "logzio"
   ],
   "dependencies": {
-    "hrtimemock": "^2.0.0",
     "json-stringify-safe": "5.0.1",
     "lodash.assign": "4.2.0",
     "moment": "^2.24.0",
@@ -50,6 +49,7 @@
     "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.2.0",
     "eslint-plugin-import": "^2.18.2",
+    "hrtimemock": "^2.0.0",
     "jest": "^24.9.0",
     "mocha": "^7.1.1",
     "nock": "^12.0.3",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "logzio"
   ],
   "dependencies": {
+    "hrtimemock": "^2.0.0",
     "json-stringify-safe": "5.0.1",
     "lodash.assign": "4.2.0",
     "moment": "^2.24.0",
@@ -53,7 +54,7 @@
     "mocha": "^7.1.1",
     "nock": "^12.0.3",
     "should": "^7.1.0",
-    "sinon": "^7.4.2"
+    "sinon": "^7.5.0"
   },
   "main": "./lib/logzio-nodejs",
   "engines": {

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -199,8 +199,20 @@ describe('logger', () => {
             assert.equal(logger._createBulk.getCall(0).args[0][0].hasOwnProperty('@timestamp_nano'), true);
 
             logger._createBulk.restore();
+
+            //testing length of nanosec-timestamp
+            const nanosec_index = 3;
+            const mock_log = {
+                message: 'hello there from test', 
+            };
+            logger._addTimestamp(mock_log);
+            let mock_nano_timestamp = mock_log['@timestamp_nano'].split("-")[nanosec_index];
+
+            assert.equal(mock_nano_timestamp.length, nanoSecDigits);
+
             logger.close();
         });
+
         it('pad nano-sec timestamp with zeros', (done) => {
             logger = createLogger({
                 bufferSize: 1,
@@ -208,14 +220,16 @@ describe('logger', () => {
                 addTimestampWithNanoSecs: true,
             });
             sinon.spy(logger, '_createBulk')
+            
             logger.log({
                 message: 'hello there from test',
             });
             logger._createBulk.restore();
             
-            const first_nano_timestamp = 234, second_nano_timestamp = 1234;
-            let padded_first_timestamp = logger.padNumberWithZeros(first_nano_timestamp);
-            let padded_second_timestamp = logger.padNumberWithZeros(second_nano_timestamp);
+            const first_nano_timestamp = 234;
+            const second_nano_timestamp = 1234;
+            let padded_first_timestamp = logger._padNumberWithZeros(first_nano_timestamp);
+            let padded_second_timestamp = logger._padNumberWithZeros(second_nano_timestamp);
 
             //testing numbers is padded with zeros to 9 digits
             assert.equal(padded_first_timestamp.length, nanoSecDigits);
@@ -223,8 +237,10 @@ describe('logger', () => {
             
             //testing padding sorts the nanosec-timestamps
             expect(nanosecAsDecimal(padded_first_timestamp) < nanosecAsDecimal(padded_second_timestamp)).toBeTruthy();
+
             logger.close();
         });
+        
         it('writes a log message without @timestamp', (done) => {
             const logger = createLogger({
                 // buffer is 2 so we could access the log before we send it, to analyze it
@@ -244,6 +260,7 @@ describe('logger', () => {
             assert.equal(fakeTime, moment(logger.messages[logger.messages.length - 1]['@timestamp'].valueOf()));
             logger.close();
         });
+
         it('writes a log message with a custom @timestamp', (done) => {
             const logger = createLogger({
                 // buffer is 2 so we could access the log before we send it, to analyze it

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -186,7 +186,7 @@ describe('logger', () => {
             logger.close();
         });
 
-        it('valid nano-sec timestamp', (done) => {
+        it('should add a valid nano-sec timestamp to the log', (done) => {
             var mockTime = 0.123456;
             var expectedLogTime = '000123456';
 
@@ -201,8 +201,8 @@ describe('logger', () => {
             logger.log({
                 message: 'hello there from test'
             })
-            const mockLog = logger._createBulk.getCall(0).args[0][0];
-            assert.equal(mockLog['@timestamp_nano'].endsWith(expectedLogTime), true);
+            const mockLogCall = logger._createBulk.getCall(0).args[0][0];
+            assert.equal(mockLogCall['@timestamp_nano'].endsWith(expectedLogTime), true);
 
             logger._createBulk.restore();
             logger.close();


### PR DESCRIPTION
@AmirTugi 
Please review change:
Fixing issue with sorting logs by nanosec-timestamp by padding the nano-timestamp with zeros.
1de20de1f9a92351ef9f0e75afa69f86f1f2aa12