### PR TITLE
add option to set/unset user-agent header

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,16 @@
+on:
+  release:
+    types: [published]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 17
+      - run: npm install
+      - run: npm test
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 .history
+.prettierignore
 node_modules

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ logger.log(obj);
 * **addTimestampWithNanoSecs** - Add a timestamp with nano seconds granularity. This is needed when many logs are sent in the same millisecond, so you can properly order the logs in kibana. The added timestamp field will be `@timestamp_nano` Default: `false`
 * **compress** - If true the the logs are compressed in gzip format. Default: `false`
 * **internalLogger** - set internal logger that supports the function log. Default: console.
+* **setUserAgent** - To sending logs we are providing for user to send logs with user-agent. To send logs without user-agent please change to `false`.  Default:`true`,
 * **extraFields** - Adds your own custom fields to each log. Add in JSON Format, for example: `extraFields : { field_1: "val_1", field_2: "val_2" , ... }`.
 
 
@@ -59,6 +60,12 @@ A few notes are worth mentioning regarding the use of the UDP protocol:
 
 
 ## Update log
+**2.0.4**
+- Add parameter to manage User-agent
+
+**2.0.3**
+- Add verbose logging to use in Azure serverless function
+
 **2.0.2**
 - Updated required fields for typescript
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ logger.log(obj);
 * **addTimestampWithNanoSecs** - Add a timestamp with nano seconds granularity. This is needed when many logs are sent in the same millisecond, so you can properly order the logs in kibana. The added timestamp field will be `@timestamp_nano` Default: `false`
 * **compress** - If true the the logs are compressed in gzip format. Default: `false`
 * **internalLogger** - set internal logger that supports the function log. Default: console.
-* **setUserAgent** - To sending logs we are providing for user to send logs with user-agent. To send logs without user-agent please change to `false`.  Default:`true`,
+* **setUserAgent** - Set `false` to send logs without user-agent field in request header.  Default:`true`,
 * **extraFields** - Adds your own custom fields to each log. Add in JSON Format, for example: `extraFields : { field_1: "val_1", field_2: "val_2" , ... }`.
 
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ logger.log(obj);
 * **addTimestampWithNanoSecs** - Add a timestamp with nano seconds granularity. This is needed when many logs are sent in the same millisecond, so you can properly order the logs in kibana. The added timestamp field will be `@timestamp_nano` Default: `false`
 * **compress** - If true the the logs are compressed in gzip format. Default: `false`
 * **internalLogger** - set internal logger that supports the function log. Default: console.
-* **setUserAgent** - Set `false` to send logs without user-agent field in request header.  Default:`true`,
+* **setUserAgent** - Set `false` to send logs without user-agent field in request header.  Default:`true`.
 * **extraFields** - Adds your own custom fields to each log. Add in JSON Format, for example: `extraFields : { field_1: "val_1", field_2: "val_2" , ... }`.
 
 

--- a/lib/logzio-nodejs.d.ts
+++ b/lib/logzio-nodejs.d.ts
@@ -1,28 +1,29 @@
 interface ILoggerOptions {
-    token: string;
-    host?: string;
-    type?: string;
-    sendIntervalMs?: number;
-    bufferSize?: number;
-    debug?: boolean;
-    numberOfRetries?: number;
-    supressErrors?: boolean;
-    addTimestampWithNanoSecs?: boolean;
-    compress?: boolean;
-    internalLogger?: { log(message: string, ...args: any[]): any } & Record<string, any>;
-    protocol?: string;
-    port?: string;
-    timeout?: number;
-    sleepUntilNextRetry?: number;
-    callback?: (err: Error, bulk: object) => void;
-    extraFields?: {};
+	token: string;
+	host?: string;
+	type?: string;
+	sendIntervalMs?: number;
+	bufferSize?: number;
+	debug?: boolean;
+	numberOfRetries?: number;
+	supressErrors?: boolean;
+	addTimestampWithNanoSecs?: boolean;
+	compress?: boolean;
+	internalLogger?: { log(message: string, ...args: any[]): any } & Record<string, any>;
+	protocol?: string;
+	setUserAgent?: boolean;
+	port?: string;
+	timeout?: number;
+	sleepUntilNextRetry?: number;
+	callback?: (err: Error, bulk: object) => void;
+	extraFields?: {};
 }
 
 interface ILogzioLogger extends ILoggerOptions {
-    jsonToString(json: string): string;
-    log(msg: any, obj?: object): void;
-    close(): void;
-    sendAndClose(callback?: (error: Error, bulk: object) => void): void;
+	jsonToString(json: string): string;
+	log(msg: any, obj?: object): void;
+	close(): void;
+	sendAndClose(callback?: (error: Error, bulk: object) => void): void;
 }
 
 export function createLogger(options: ILoggerOptions): ILogzioLogger;

--- a/lib/logzio-nodejs.js
+++ b/lib/logzio-nodejs.js
@@ -53,6 +53,7 @@ class LogzioLogger {
         timeout,
         sleepUntilNextRetry = 2 * 1000,
         callback = this._defaultCallback,
+		setUserAgent = true,
         extraFields = {},
     }) {
         if (!token) {
@@ -71,7 +72,7 @@ class LogzioLogger {
         this.compress = compress;
         this.internalLogger = internalLogger;
         this.sleepUntilNextRetry = sleepUntilNextRetry;
-
+		this.setUserAgent = setUserAgent;
         this.timer = null;
         this.closed = false;
 
@@ -253,14 +254,25 @@ class LogzioLogger {
 
     _send(bulk) {
         const body = messagesToBody(bulk.msgs);
+		let headersOpt;
+		if(this.setUserAgent){
+			headersOpt={
+					host: this.host,
+					accept: '*/*',
+					'user-agent': USER_AGENT,
+					'content-type': 'text/plain',
+				}
+			
+		}else{
+			headersOpt={
+				host: this.host,
+				accept: '*/*',
+				'content-type': 'text/plain',
+			}
+		}
         const options = {
             uri: this.url,
-            headers: {
-                host: this.host,
-                accept: '*/*',
-                'user-agent': USER_AGENT,
-                'content-type': 'text/plain',
-            },
+            headers: headersOpt
         };
 
         if (typeof this.timeout !== 'undefined') {

--- a/lib/logzio-nodejs.js
+++ b/lib/logzio-nodejs.js
@@ -53,7 +53,7 @@ class LogzioLogger {
         timeout,
         sleepUntilNextRetry = 2 * 1000,
         callback = this._defaultCallback,
-		setUserAgent = true,
+        setUserAgent = true,
         extraFields = {},
     }) {
         if (!token) {
@@ -72,7 +72,7 @@ class LogzioLogger {
         this.compress = compress;
         this.internalLogger = internalLogger;
         this.sleepUntilNextRetry = sleepUntilNextRetry;
-		this.setUserAgent = setUserAgent;
+        this.setUserAgent = setUserAgent;
         this.timer = null;
         this.closed = false;
 
@@ -254,22 +254,21 @@ class LogzioLogger {
 
     _send(bulk) {
         const body = messagesToBody(bulk.msgs);
-		let headersOpt;
-		if(this.setUserAgent){
-			headersOpt={
-					host: this.host,
-					accept: '*/*',
-					'user-agent': USER_AGENT,
-					'content-type': 'text/plain',
-				}
-			
-		}else{
-			headersOpt={
-				host: this.host,
-				accept: '*/*',
-				'content-type': 'text/plain',
-			}
-		}
+        let headersOpt;
+        if (this.setUserAgent) {
+            headersOpt = {
+                host: this.host,
+                accept: '*/*',
+                'user-agent': USER_AGENT,
+                'content-type': 'text/plain',
+            };
+        } else {
+            headersOpt = {
+                host: this.host,
+                accept: '*/*',
+                'content-type': 'text/plain',
+            };
+        }
         const options = {
             uri: this.url,
             headers: headersOpt

--- a/lib/logzio-nodejs.js
+++ b/lib/logzio-nodejs.js
@@ -254,24 +254,14 @@ class LogzioLogger {
 
     _send(bulk) {
         const body = messagesToBody(bulk.msgs);
-        let headersOpt;
-        if (this.setUserAgent) {
-            headersOpt = {
-                host: this.host,
-                accept: '*/*',
-                'user-agent': USER_AGENT,
-                'content-type': 'text/plain',
-            };
-        } else {
-            headersOpt = {
-                host: this.host,
-                accept: '*/*',
-                'content-type': 'text/plain',
-            };
-        }
         const options = {
             uri: this.url,
-            headers: headersOpt
+            headers: {
+                host: this.host,
+                accept: '*/*',
+                'content-type': 'text/plain',
+                ...(this.setUserAgent ? { 'user-agent': USER_AGENT } : {}),
+            },
         };
 
         if (typeof this.timeout !== 'undefined') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "logzio-nodejs",
-  "version": "2.0.3-beta",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.0.3-beta",
+      "name": "logzio-nodejs",
+      "version": "2.0.3",
       "license": "(Apache-2.0)",
       "dependencies": {
         "json-stringify-safe": "5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "json-stringify-safe": "5.0.1",
         "lodash.assign": "4.2.0",
-        "moment": "^2.24.0",
+        "moment": "2.29.2",
         "request": "^2.88.0",
         "request-promise": "^4.2.4"
       },
@@ -5273,9 +5273,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "version": "2.29.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
+      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
       "engines": {
         "node": "*"
       }
@@ -12020,9 +12020,9 @@
       }
     },
     "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+      "version": "2.29.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
+      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "logzio-nodejs",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "logzio-nodejs",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "(Apache-2.0)",
       "dependencies": {
         "json-stringify-safe": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "json-stringify-safe": "5.0.1",
     "lodash.assign": "4.2.0",
-    "moment": "^2.24.0",
+    "moment": "2.29.2",
     "request": "^2.88.0",
     "request-promise": "^4.2.4"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "logzio-nodejs",
   "description": "A nodejs implementation for sending logs to Logz.IO cloud service Copy of logzio-nodejs",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "author": "Gilly Barr <gilly@logz.io>",
   "contributors": [
     {
@@ -23,7 +23,11 @@
     {
       "name": "Roni Shaham",
       "email": "ronish31@gmail.com"
-    }
+    },
+	{
+		"name": "Anton Kolomiiets",
+		"email": "resdenia@gmail.com"
+	}
   ],
   "repository": {
     "type": "git",

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -59,6 +59,21 @@ describe('logger', () => {
             logger.close();
         });
 
+        it('sends log without user-agent header', (done) => {
+            const logger = createLogger({
+                bufferSize: 1,
+                callback: done,
+				setUserAgent:false
+            });
+            sinon.spy(logger, '_createBulk');
+
+            const logMsg = 'hello there from test';
+            logger.log(logMsg);
+            assert.equal(logger._createBulk.getCall(0).args[0][0].message, logMsg);
+            logger._createBulk.restore();
+            logger.close();
+        });
+
         it('should send a log with an object as additional param', (done) => {
             const logger = createLogger({
                 bufferSize: 1,

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -62,16 +62,20 @@ describe('logger', () => {
         it('sends log without user-agent header', (done) => {
             const logger = createLogger({
                 bufferSize: 1,
-                callback: done,
-				setUserAgent:false
+                callback: onDone,
+                setUserAgent:false
             });
-            sinon.spy(logger, '_createBulk');
+            sinon.spy(logger, '_tryToSend');
 
             const logMsg = 'hello there from test';
             logger.log(logMsg);
-            assert.equal(logger._createBulk.getCall(0).args[0][0].message, logMsg);
-            logger._createBulk.restore();
-            logger.close();
+
+            function onDone() {
+                assert.equal(logger._tryToSend.getCall(0).args[0].headers['user-agent'], undefined);
+                logger._tryToSend.restore();
+                logger.close();
+                done();
+            }
         });
 
         it('should send a log with an object as additional param', (done) => {


### PR DESCRIPTION
To solve the `cors` issue in firefox we need to  give the possibility to send logs without `user-agent` header.

![Group 2293](https://user-images.githubusercontent.com/11467909/172618595-e7b33de2-1010-4576-ae31-3f7b197efdfd.jpg)

