### PR TITLE
Add method to flush the list of logs

### DIFF
--- a/lib/logzio-nodejs.d.ts
+++ b/lib/logzio-nodejs.d.ts
@@ -23,6 +23,7 @@ interface ILogzioLogger extends ILoggerOptions {
 	log(msg: any, obj?: object): void;
 	close(): void;
 	sendAndClose(callback?: (error: Error, bulk: object) => void): void;
+	flush(callback?: (error: Error, bulk: object) => void): void;
 }
 
 export function createLogger(options: ILoggerOptions): ILogzioLogger;

--- a/lib/logzio-nodejs.js
+++ b/lib/logzio-nodejs.js
@@ -130,6 +130,12 @@ class LogzioLogger {
         }
     }
 
+    flush(callback) {
+        this.callback = callback || this._defaultCallback;
+        this._debug('Flushing messages...');
+        this._popMsgsAndSend();
+    }
+
     sendAndClose(callback) {
         this.callback = callback || this._defaultCallback;
         this._debug('Sending last messages and closing...');

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -652,15 +652,15 @@ describe('logger', () => {
 
             const logger = createLogger({
                 bufferSize,
-                callback: assertCalled,
             });
 
-            Array(count).fill().forEach((item, i) => {
+            Array(logCount).fill().forEach((item, i) => {
                 logger.log({
-                    message: `${message} #${i}`,
+                    message: `hello there from test #${i}`,
                     id: i,
                 });
-                logger.flush();
+
+                logger.flush(assertCalled);
             });
 
             logger.close();

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -617,4 +617,53 @@ describe('logger', () => {
             logger.close();
         });
     });
+
+    describe('Flush log messages', () => {
+
+        afterAll((done) => {
+            axiosInstance.post.restore();
+            done();
+        });
+
+        beforeAll((done) => {
+            sinon
+                .stub(axiosInstance, 'post')
+                .resolves({
+                    statusCode: 200,
+                });
+            done();
+        });
+
+        it('should send one log at a time', (done) => {
+            let timesCalled = 0;
+            const bufferSize = 3;
+            const logCount = 3;
+            const expectedTimes = 3;
+
+            function assertCalled() {
+                timesCalled += 1;
+
+                if (logCount === timesCalled) {
+                    done();
+                } else if (timesCalled > expectedTimes) {
+                    throw new Error('called less times than expected');
+                }
+            }
+
+            const logger = createLogger({
+                bufferSize,
+                callback: assertCalled,
+            });
+
+            Array(count).fill().forEach((item, i) => {
+                logger.log({
+                    message: `${message} #${i}`,
+                    id: i,
+                });
+                logger.flush();
+            });
+
+            logger.close();
+        });
+    });
 });


### PR DESCRIPTION
## Description 

This PR adds the feature to flush the messages list. This feature is relevant if logzio-js is being used in a serverless service, meaning there is no need to close the connection to ensure that messages are sent.

Also related to this issue: https://github.com/logzio/logzio-nodejs/issues/101

## What type of PR is this?

- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
