### PR TITLE
[Bugfix] incompatible opentelemetry package version

### DIFF
--- a/.github/workflows/test-nodejs.yml
+++ b/.github/workflows/test-nodejs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [ 16.x, 18.x, 20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-nodejs.yml
+++ b/.github/workflows/test-nodejs.yml
@@ -14,12 +14,11 @@ jobs:
         node-version: [14.x, 16.x, 18.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
       - run: npm ci
       - run: npm install --save request
       - run: npm run test

--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ var logger = require('logzio-nodejs').createLogger({
   ```
 
 ## Update log
+**2.3.1**
+- Update dependencies:
+  - `@opentelemetry/context-async-hooks` -> `^2.0.0`
+  - `@opentelemetry/sdk-trace-node` -> `^2.0.0`
+- Fix service name retrieval in `_addOpentelemetryContext`
 
 **2.3.0**
 - Add a method to flush the list of logs (@MarceloRGonc)

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ var logger = require('logzio-nodejs').createLogger({
   - `@opentelemetry/context-async-hooks` -> `^2.0.0`
   - `@opentelemetry/sdk-trace-node` -> `^2.0.0`
 - Fix service name retrieval in `_addOpentelemetryContext`
+- Drop support for `Node 14` 
 
 **2.3.0**
 - Add a method to flush the list of logs (@MarceloRGonc)

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ var logger = require('logzio-nodejs').createLogger({
   ```
 
 ## Update log
-**2.3.1**
+**2.4.0**
 - Update dependencies:
   - `@opentelemetry/context-async-hooks` -> `^2.0.0`
   - `@opentelemetry/sdk-trace-node` -> `^2.0.0`

--- a/lib/logzio-nodejs.js
+++ b/lib/logzio-nodejs.js
@@ -253,7 +253,7 @@ class LogzioLogger {
       if (span) {
         msg.trace_id = span.spanContext().traceId;
         msg.span_id = span.spanContext().spanId;
-        msg.service_name = span.resource._attributes['service.name'];
+        msg.service_name = span.resource.attributes['service.name'];
       }
     }
     log(msg, obj) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "(Apache-2.0)",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^1.30.0",
-        "@opentelemetry/sdk-trace-node": "^1.30.0",
+        "@opentelemetry/context-async-hooks": "^2.0.0",
+        "@opentelemetry/sdk-trace-node": "^2.0.0",
         "axios": "^1.6.4",
         "json-stringify-safe": "5.0.1",
         "lodash.assign": "4.2.0",
@@ -1392,131 +1392,86 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.0.tgz",
-      "integrity": "sha512-roCetrG/cz0r/gugQm/jFo75UxblVvHaNSRoR0kSSRSzXFAiIBqFCZuH458BHBNRtRe+0yJdIJ21L9t94bw7+g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.0.0.tgz",
+      "integrity": "sha512-IEkJGzK1A9v3/EHjXh3s2IiFc6L4jfK+lNgKVgUjeUJQRRhnVFMIO3TAvKwonm9O1HebCuoOt98v8bZW7oVQHA==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.0.tgz",
-      "integrity": "sha512-Q/3u/K73KUjTCnFUP97ZY+pBjQ1kPEgjOfXj/bJl8zW7GbXdkw6cwuyZk6ZTXkVgCBsYRYUzx4fvYK1jxdb9MA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.30.0.tgz",
-      "integrity": "sha512-lcobQQmd+hLdtxJJKu/i51lNXmF1PJJ7Y9B97ciHRVQuMI260vSZG7Uf4Zg0fqR8PB+fT/7rnlDwS0M7QldZQQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "1.30.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.30.0.tgz",
-      "integrity": "sha512-0hdP495V6HPRkVpowt54+Swn5NdesMIRof+rlp0mbnuIUOM986uF+eNxnPo9q5MmJegVBRTxgMHXXwvnXRnKRg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "1.30.0"
-      },
-      "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.0.tgz",
-      "integrity": "sha512-5mGMjL0Uld/99t7/pcd7CuVtJbkARckLVuiOX84nO8RtLtIz0/J6EOHM2TGvPZ6F4K+XjUq13gMx14w80SVCQg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.0.tgz",
-      "integrity": "sha512-RKQDaDIkV7PwizmHw+rE/FgfB2a6MBx+AEVVlAHXRG1YYxLiBpPX2KhmoB99R5vA4b72iJrjle68NDWnbrE9Dg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
+      "integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/resources": "1.30.0",
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.30.0.tgz",
-      "integrity": "sha512-MeXkXEdBs9xq1JSGTr/3P1lHBSUBaVmo1+UpoQhUpviPMzDXy0MNsdTC7KKI6/YcG74lTX6eqeNjlC1jV4Rstw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.0.0.tgz",
+      "integrity": "sha512-omdilCZozUjQwY3uZRBwbaRMJ3p09l4t187Lsdf0dGMye9WKD4NGcpgZRvqhI1dwcH6og+YXQEtoO9Wx3ykilg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.30.0",
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/propagator-b3": "1.30.0",
-        "@opentelemetry/propagator-jaeger": "1.30.0",
-        "@opentelemetry/sdk-trace-base": "1.30.0",
-        "semver": "^7.5.2"
+        "@opentelemetry/context-async-hooks": "2.0.0",
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/sdk-trace-base": "2.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-trace-node/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.32.0.tgz",
+      "integrity": "sha512-s0OpmpQFSfMrmedAn9Lhg4KWJELHCU6uU9dtIJ28N8UGhf9Y55im5X8fEzwhwDwiSqN+ZPSNrDJF7ivf/AuRPQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -8762,78 +8717,52 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
     },
     "@opentelemetry/context-async-hooks": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.0.tgz",
-      "integrity": "sha512-roCetrG/cz0r/gugQm/jFo75UxblVvHaNSRoR0kSSRSzXFAiIBqFCZuH458BHBNRtRe+0yJdIJ21L9t94bw7+g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.0.0.tgz",
+      "integrity": "sha512-IEkJGzK1A9v3/EHjXh3s2IiFc6L4jfK+lNgKVgUjeUJQRRhnVFMIO3TAvKwonm9O1HebCuoOt98v8bZW7oVQHA==",
       "requires": {}
     },
     "@opentelemetry/core": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.0.tgz",
-      "integrity": "sha512-Q/3u/K73KUjTCnFUP97ZY+pBjQ1kPEgjOfXj/bJl8zW7GbXdkw6cwuyZk6ZTXkVgCBsYRYUzx4fvYK1jxdb9MA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
-      }
-    },
-    "@opentelemetry/propagator-b3": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.30.0.tgz",
-      "integrity": "sha512-lcobQQmd+hLdtxJJKu/i51lNXmF1PJJ7Y9B97ciHRVQuMI260vSZG7Uf4Zg0fqR8PB+fT/7rnlDwS0M7QldZQQ==",
-      "requires": {
-        "@opentelemetry/core": "1.30.0"
-      }
-    },
-    "@opentelemetry/propagator-jaeger": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.30.0.tgz",
-      "integrity": "sha512-0hdP495V6HPRkVpowt54+Swn5NdesMIRof+rlp0mbnuIUOM986uF+eNxnPo9q5MmJegVBRTxgMHXXwvnXRnKRg==",
-      "requires": {
-        "@opentelemetry/core": "1.30.0"
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.0.tgz",
-      "integrity": "sha512-5mGMjL0Uld/99t7/pcd7CuVtJbkARckLVuiOX84nO8RtLtIz0/J6EOHM2TGvPZ6F4K+XjUq13gMx14w80SVCQg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
       "requires": {
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       }
     },
     "@opentelemetry/sdk-trace-base": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.0.tgz",
-      "integrity": "sha512-RKQDaDIkV7PwizmHw+rE/FgfB2a6MBx+AEVVlAHXRG1YYxLiBpPX2KhmoB99R5vA4b72iJrjle68NDWnbrE9Dg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
+      "integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
       "requires": {
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/resources": "1.30.0",
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       }
     },
     "@opentelemetry/sdk-trace-node": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.30.0.tgz",
-      "integrity": "sha512-MeXkXEdBs9xq1JSGTr/3P1lHBSUBaVmo1+UpoQhUpviPMzDXy0MNsdTC7KKI6/YcG74lTX6eqeNjlC1jV4Rstw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.0.0.tgz",
+      "integrity": "sha512-omdilCZozUjQwY3uZRBwbaRMJ3p09l4t187Lsdf0dGMye9WKD4NGcpgZRvqhI1dwcH6og+YXQEtoO9Wx3ykilg==",
       "requires": {
-        "@opentelemetry/context-async-hooks": "1.30.0",
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/propagator-b3": "1.30.0",
-        "@opentelemetry/propagator-jaeger": "1.30.0",
-        "@opentelemetry/sdk-trace-base": "1.30.0",
-        "semver": "^7.5.2"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
-        }
+        "@opentelemetry/context-async-hooks": "2.0.0",
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/sdk-trace-base": "2.0.0"
       }
     },
     "@opentelemetry/semantic-conventions": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.32.0.tgz",
+      "integrity": "sha512-s0OpmpQFSfMrmedAn9Lhg4KWJELHCU6uU9dtIJ28N8UGhf9Y55im5X8fEzwhwDwiSqN+ZPSNrDJF7ivf/AuRPQ=="
     },
     "@sinclair/typebox": {
       "version": "0.27.8",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
   ],
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/context-async-hooks": "^1.30.0",
-    "@opentelemetry/sdk-trace-node": "^1.30.0",
+    "@opentelemetry/context-async-hooks": "^2.0.0",
+    "@opentelemetry/sdk-trace-node": "^2.0.0",
     "axios": "^1.6.4",
     "json-stringify-safe": "5.0.1",
     "lodash.assign": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "logzio-nodejs",
   "description": "A nodejs implementation for sending logs to Logz.IO cloud service Copy of logzio-nodejs",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "author": "Gilly Barr <gilly@logz.io>",
   "maintainers": [
     {

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -61,6 +61,7 @@ describe('logger', () => {
         const loggedMessage = logger._createBulk.getCall(0).args[0][0];
         assert(loggedMessage.trace_id, 'trace_id should exist');
         assert(loggedMessage.span_id, 'span_id should exist');
+        logger.close();
       });
     
       it('should not attach traceId or spanId when no span is active', () => {
@@ -77,6 +78,7 @@ describe('logger', () => {
         const loggedMessage = logger._createBulk.getCall(0).args[0][0];
         assert.strictEqual(loggedMessage.trace_id, undefined, 'trace_id should not exist');
         assert.strictEqual(loggedMessage.span_id, undefined, 'span_id should not exist');
+        logger.close();
       });
     });
     describe('logs a single line', () => {


### PR DESCRIPTION
## Description 

Solves: #137 

**2.4.0**
- Update dependencies:
  - `@opentelemetry/context-async-hooks` -> `^2.0.0`
  - `@opentelemetry/sdk-trace-node` -> `^2.0.0`
- Fix service name retrieval in `_addOpentelemetryContext`
- Drop support for `Node 14` 

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
