### PR TITLE
[Bugfix] add open telemetry context error while sending logs

### DIFF
--- a/.github/workflows/test-nodejs.yml
+++ b/.github/workflows/test-nodejs.yml
@@ -1,27 +1,46 @@
 # This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js test
+name: Node.js Tests
 
 on:
   pull_request:
     branches: [ development, master, main ]
+
 jobs:
-  build:
+  unit-tests:
+    name: Unit Tests
     runs-on: ubuntu-latest
-    env:
-      LOGZIO_API_TOKEN: ${{ secrets.LOGZIO_API_TOKEN }}
-      LOGZIO_LOGS_TOKEN: ${{ secrets.LOGZIO_LOGS_TOKEN }}
     strategy:
       matrix:
         node-version: [ 16.x, 18.x, 20.x, 22.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
-      - run: npm install --save request
-      - run: npm run test
+      - name: Install dependencies
+        run: npm ci
+      - name: Run unit tests
+        run: npm test -- --testPathIgnorePatterns=e2e.test.js
+
+  e2e-tests:
+    name: End-to-End Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ 16.x, 18.x, 20.x, 22.x]
+    env:
+      LOGZIO_API_TOKEN: ${{ secrets.LOGZIO_API_TOKEN }}
+      LOGZIO_SHIPPING_TOKEN: ${{ secrets.LOGZIO_SHIPPING_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: npm ci
+      - name: Run E2E tests
+        run: npm run test:e2e

--- a/.github/workflows/test-nodejs.yml
+++ b/.github/workflows/test-nodejs.yml
@@ -33,7 +33,7 @@ jobs:
         node-version: [ 16.x, 18.x, 20.x, 22.x]
     env:
       LOGZIO_API_TOKEN: ${{ secrets.LOGZIO_API_TOKEN }}
-      LOGZIO_SHIPPING_TOKEN: ${{ secrets.LOGZIO_SHIPPING_TOKEN }}
+      LOGZIO_LOGS_TOKEN: ${{ secrets.LOGZIO_LOGS_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js

--- a/.github/workflows/test-nodejs.yml
+++ b/.github/workflows/test-nodejs.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      LOGZIO_API_TOKEN: ${{ secrets.LOGZIO_API_TOKEN }}
+      LOGZIO_SHIPPING_TOKEN: ${{ secrets.LOGZIO_SHIPPING_TOKEN }}
     strategy:
       matrix:
         node-version: [ 16.x, 18.x, 20.x, 22.x]

--- a/.github/workflows/test-nodejs.yml
+++ b/.github/workflows/test-nodejs.yml
@@ -3,6 +3,9 @@
 
 name: Node.js Tests
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ development, master, main ]

--- a/.github/workflows/test-nodejs.yml
+++ b/.github/workflows/test-nodejs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LOGZIO_API_TOKEN: ${{ secrets.LOGZIO_API_TOKEN }}
-      LOGZIO_SHIPPING_TOKEN: ${{ secrets.LOGZIO_SHIPPING_TOKEN }}
+      LOGZIO_LOGS_TOKEN: ${{ secrets.LOGZIO_LOGS_TOKEN }}
     strategy:
       matrix:
         node-version: [ 16.x, 18.x, 20.x, 22.x]

--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ var logger = require('logzio-nodejs').createLogger({
   ```
 
 ## Update log
+**2.5.0**
+- Add null checks for `span.resource.attributes` in `_addOpentelemetryContext()`.
+- Add try catch block in `_addOpentelemetryContext()`.
+- Add `addOtelContex`t to `ILoggerOptions` ts defenition.
+- Added e2e tests
+
 **2.4.0**
 - Update dependencies:
   - `@opentelemetry/context-async-hooks` -> `^2.0.0`

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ var logger = require('logzio-nodejs').createLogger({
 **2.5.0**
 - Add null checks for `span.resource.attributes` in `_addOpentelemetryContext()`.
 - Add try catch block in `_addOpentelemetryContext()`.
-- Add `addOtelContex`t to `ILoggerOptions` ts defenition.
+- Add `addOtelContex` to `ILoggerOptions` TypeScript defenition.
 - Added e2e tests
 
 **2.4.0**

--- a/lib/logzio-nodejs.d.ts
+++ b/lib/logzio-nodejs.d.ts
@@ -16,6 +16,7 @@ interface ILoggerOptions {
 	sleepUntilNextRetry?: number;
 	callback?: (err: Error, bulk: object) => void;
 	extraFields?: {};
+	addOtelContext?: boolean;
 }
 
 interface ILogzioLogger extends ILoggerOptions {

--- a/lib/logzio-nodejs.js
+++ b/lib/logzio-nodejs.js
@@ -241,20 +241,31 @@ class LogzioLogger {
         }
     }
     /**
-      * Attach OpenTelemetry context to the log record.
-      * @param msg - The message (Object) to append the OpenTelemetry context to.
-      * @private
-      */
+     * Attach OpenTelemetry context to the log record.
+     * @param msg - The message (Object) to append the OpenTelemetry context to.
+     * @private
+     */
     _addOpentelemetryContext(msg) {
       if (!this.addOtelContext) {
         return;
       }
-      let span = trace.getSpan(context.active());
-      if (span) {
-        msg.trace_id = span.spanContext().traceId;
-        msg.span_id = span.spanContext().spanId;
-        msg.service_name = span.resource.attributes['service.name'];
+      
+      try {
+        const span = trace.getSpan(context.active());
+        if (span) {
+          msg.trace_id = span.spanContext().traceId;
+          msg.span_id = span.spanContext().spanId;
+          
+          if (span.resource && span.resource.attributes) {
+            msg.service_name = span.resource.attributes['service.name'];
+          }
+        }
+      } catch (err) {
+        if (this.debug) {
+          this.internalLogger.log(`logzio-nodejs: Error in _addOpentelemetryContext - ${err.message}`);
+        }
       }
+    }
     }
     log(msg, obj) {
       if (this.closed === true) {

--- a/lib/logzio-nodejs.js
+++ b/lib/logzio-nodejs.js
@@ -266,7 +266,8 @@ class LogzioLogger {
         }
       }
     }
-    }
+    
+    
     log(msg, obj) {
       if (this.closed === true) {
         throw new Error('Logging into a logger that has been closed!');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "logzio-nodejs",
-  "version": "2.3.0",
+  "version": "2.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "logzio-nodejs",
-      "version": "2.3.0",
+      "version": "2.5.0",
       "license": "(Apache-2.0)",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -28,7 +28,8 @@
         "mocha": "^7.1.1",
         "nock": "^12.0.3",
         "should": "^7.1.0",
-        "sinon": "^7.5.0"
+        "sinon": "^7.5.0",
+        "uuid": "^9.0.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -7393,6 +7394,20 @@
         "inherits": "2.0.1"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.3",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz",
@@ -13317,6 +13332,12 @@
       "requires": {
         "inherits": "2.0.1"
       }
+    },
+    "uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true
     },
     "v8-to-istanbul": {
       "version": "9.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "logzio-nodejs",
   "description": "A nodejs implementation for sending logs to Logz.IO cloud service Copy of logzio-nodejs",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "author": "Gilly Barr <gilly@logz.io>",
   "maintainers": [
     {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "assert": "^1.5.0",
+    "uuid": "^9.0.0",
     "async": "1.4.2",
     "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.2.0",
@@ -75,6 +76,7 @@
   "license": "(Apache-2.0)",
   "scripts": {
     "test": "jest",
+    "test:e2e": "jest e2e.test.js",
     "detached": "jest --detectOpenHandles",
     "watch": "jest --watch"
   }

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -7,8 +7,8 @@ const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
 const { AsyncHooksContextManager } = require('@opentelemetry/context-async-hooks');
 
 const LOGZIO_API_TOKEN = process.env.LOGZIO_API_TOKEN; 
-const LOGZIO_SHIPPING_TOKEN = process.env.LOGZIO_SHIPPING_TOKEN;
-const runE2ETests = LOGZIO_API_TOKEN && LOGZIO_SHIPPING_TOKEN;
+const LOGZIO_LOGS_TOKEN = process.env.LOGZIO_LOGS_TOKEN;
+const runE2ETests = LOGZIO_API_TOKEN && LOGZIO_LOGS_TOKEN;
 
 /**
  * Polls the Logz.io Search API until a log with the given run_id is found, or times out.
@@ -89,7 +89,7 @@ const setupOtelContext = () => {
     console.log(`Starting E2E test with test_run_id=${testRunId}`);
     
     const logger = logzioLogger.createLogger({
-      token: LOGZIO_SHIPPING_TOKEN,
+      token: LOGZIO_LOGS_TOKEN,
       type: 'nodejs-e2e-test',
       debug: true
     });
@@ -120,7 +120,7 @@ const setupOtelContext = () => {
     console.log(`Starting E2E test for additional fields with test_run_id=${testRunId}`);
     
     const logger = logzioLogger.createLogger({
-      token: LOGZIO_SHIPPING_TOKEN,
+      token: LOGZIO_LOGS_TOKEN,
       type: 'nodejs-e2e-test',
       debug: true,
       extraFields: {
@@ -157,7 +157,7 @@ const setupOtelContext = () => {
     const { tracer, cleanup } = setupOtelContext();
     
     const logger = logzioLogger.createLogger({
-      token: LOGZIO_SHIPPING_TOKEN,
+      token: LOGZIO_LOGS_TOKEN,
       type: 'nodejs-e2e-test-otel',
       debug: true,
       addOtelContext: true
@@ -203,10 +203,10 @@ const setupOtelContext = () => {
     console.log(`Starting E2E test for no OpenTelemetry context with test_run_id=${testRunId}`);
     
     const logger = logzioLogger.createLogger({
-      token: LOGZIO_SHIPPING_TOKEN,
+      token: LOGZIO_LOGS_TOKEN,
       type: 'nodejs-e2e-test-no-otel',
       debug: true,
-      addOtelContext: true  // Enable OpenTelemetry context, but no context exists
+      addOtelContext: true 
     });
     
     logger.log({

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -1,0 +1,228 @@
+const assert = require('assert');
+const axios = require('axios');
+const { v4: uuidv4 } = require('uuid');
+const logzioLogger = require('../lib/logzio-nodejs.js');
+const { trace, context, SpanStatusCode } = require('@opentelemetry/api');
+const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
+const { AsyncHooksContextManager } = require('@opentelemetry/context-async-hooks');
+
+const LOGZIO_API_TOKEN = process.env.LOGZIO_API_TOKEN; 
+const LOGZIO_SHIPPING_TOKEN = process.env.LOGZIO_SHIPPING_TOKEN;
+const runE2ETests = LOGZIO_API_TOKEN && LOGZIO_SHIPPING_TOKEN;
+
+/**
+ * Polls the Logz.io Search API until a log with the given run_id is found, or times out.
+ * @param {string} runId - Unique identifier for the test run
+ * @param {string} apiToken - Logz.io API token
+ * @param {number} timeout - Max seconds to poll before failing the test
+ * @param {number} interval - Seconds between polling attempts
+ * @returns {Promise<object>} - The found log or rejects if not found
+ */
+const fetchAndAssertLogs = async (runId, apiToken, timeout = 120, interval = 5) => {
+  const url = "https://api.logz.io/v1/search";
+  const payload = {
+    query: { query_string: { query: `test_run_id:${runId}` } },
+    from: 0, 
+    size: 1,
+    sort: [{ "@timestamp": { order: "desc" } }]
+  };
+  
+  const headers = { 
+    "Content-Type": "application/json", 
+    "X-API-TOKEN": apiToken 
+  };
+  
+  const endTime = Date.now() + (timeout * 1000);
+  
+  while (Date.now() < endTime) {
+    try {
+      const response = await axios.post(url, payload, { headers });
+      const hits = response.data?.hits?.total;
+      
+      let hitCount = 0;
+      if (typeof hits === 'object') {
+        hitCount = hits?.value || 0;
+      } else {
+        hitCount = hits || 0;
+      }
+      
+      if (hitCount > 0) {
+        console.log(`Found ${hitCount} log(s) for run_id=${runId}`);
+        return response.data.hits.hits[0]._source;
+      }
+    } catch (error) {
+      console.error("Error polling Logz.io API:", error.message);
+    }
+    
+    await new Promise(resolve => setTimeout(resolve, interval * 1000));
+  }
+  
+  throw new Error(`No logs found for test_run_id=${runId} after ${timeout}s`);
+};
+
+/**
+ * Setup OpenTelemetry trace context for testing
+ * @returns {object} Object containing tracer and cleanup function
+ */
+const setupOtelContext = () => {
+  const provider = new NodeTracerProvider();
+  provider.register();
+  
+  const contextManager = new AsyncHooksContextManager();
+  contextManager.enable();
+  context.setGlobalContextManager(contextManager);
+  
+  const tracer = trace.getTracer('logzio-test-tracer');
+  
+  return {
+    tracer,
+    cleanup: () => {
+      contextManager.disable();
+    }
+  };
+};
+
+(runE2ETests ? describe : describe.skip)('Logzio Logger E2E Tests', () => {
+  jest.setTimeout(180000); 
+  it('should successfully send logs to Logz.io and validate they arrive', async () => {
+    const testRunId = uuidv4();
+    console.log(`Starting E2E test with test_run_id=${testRunId}`);
+    
+    const logger = logzioLogger.createLogger({
+      token: LOGZIO_SHIPPING_TOKEN,
+      type: 'nodejs-e2e-test',
+      debug: true
+    });
+    
+    const logMessage = {
+      message: 'E2E test log message',
+      test_run_id: testRunId,
+      environment: 'test',
+      framework: 'jest',
+      timestamp: new Date().toISOString()
+    };
+    
+    logger.log(logMessage);
+    
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    
+    logger.close();
+    
+    const foundLog = await fetchAndAssertLogs(testRunId, LOGZIO_API_TOKEN);
+    
+    assert(foundLog.test_run_id === testRunId, 'test_run_id should match');
+    assert(foundLog.message === logMessage.message, 'message should match');
+    assert(foundLog.environment === 'test', 'environment should be test');
+  });
+  
+  it('should include additional fields in the logs', async () => {
+    const testRunId = uuidv4();
+    console.log(`Starting E2E test for additional fields with test_run_id=${testRunId}`);
+    
+    const logger = logzioLogger.createLogger({
+      token: LOGZIO_SHIPPING_TOKEN,
+      type: 'nodejs-e2e-test',
+      debug: true,
+      extraFields: {
+        service: 'logger-test',
+        version: '1.0.0',
+        environment: 'testing'
+      }
+    });
+    
+    const logCount = 3;
+    for (let i = 0; i < logCount; i++) {
+      logger.log({
+        message: `E2E test log message #${i}`,
+        test_run_id: testRunId,
+        iteration: i
+      });
+    }
+    
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    logger.close();
+    
+    const foundLog = await fetchAndAssertLogs(testRunId, LOGZIO_API_TOKEN);
+    
+    assert(foundLog.service === 'logger-test', 'service field should be present');
+    assert(foundLog.version === '1.0.0', 'version field should be present');
+    assert(foundLog.environment === 'testing', 'environment field should be present');
+    assert(foundLog.test_run_id === testRunId, 'test_run_id should match');
+  });
+
+  it('should include OpenTelemetry context data in logs when addOtelContext is enabled', async () => {
+    const testRunId = uuidv4();
+    console.log(`Starting E2E test for OpenTelemetry context with test_run_id=${testRunId}`);
+    
+    const { tracer, cleanup } = setupOtelContext();
+    
+    const logger = logzioLogger.createLogger({
+      token: LOGZIO_SHIPPING_TOKEN,
+      type: 'nodejs-e2e-test-otel',
+      debug: true,
+      addOtelContext: true
+    });
+    
+    let spanToVerify;
+    await tracer.startActiveSpan('test-otel-span', async (span) => {
+      spanToVerify = span;
+      
+      logger.log({
+        message: 'E2E test log with OpenTelemetry context',
+        test_run_id: testRunId,
+        test_type: 'otel-context'
+      });
+      
+      span.setAttribute('test.run_id', testRunId);
+      
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      
+      span.setStatus({ code: SpanStatusCode.OK });
+      span.end();
+    });
+    
+    logger.close();
+    
+    cleanup();
+    
+    const foundLog = await fetchAndAssertLogs(testRunId, LOGZIO_API_TOKEN);
+    
+    assert(foundLog.test_run_id === testRunId, 'test_run_id should match');
+    assert(foundLog.message === 'E2E test log with OpenTelemetry context', 'message should match');
+    assert(foundLog.trace_id, 'trace_id should be present');
+    assert(foundLog.span_id, 'span_id should be present');
+    
+    if (spanToVerify) {
+      assert(foundLog.trace_id === spanToVerify.spanContext().traceId, 'trace_id should match the span context');
+      assert(foundLog.span_id === spanToVerify.spanContext().spanId, 'span_id should match the span context');
+    }
+  });
+
+  it('should not crash when no OpenTelemetry context data in logs and addOtelContext is enabled', async () => {
+    const testRunId = uuidv4();
+    console.log(`Starting E2E test for no OpenTelemetry context with test_run_id=${testRunId}`);
+    
+    const logger = logzioLogger.createLogger({
+      token: LOGZIO_SHIPPING_TOKEN,
+      type: 'nodejs-e2e-test-no-otel',
+      debug: true,
+      addOtelContext: true  // Enable OpenTelemetry context, but no context exists
+    });
+    
+    logger.log({
+      message: 'E2E test log with addOtelContext enabled but no active span',
+      test_run_id: testRunId,
+      test_type: 'no-otel-context'
+    });
+    
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    
+    logger.close();
+    
+    const foundLog = await fetchAndAssertLogs(testRunId, LOGZIO_API_TOKEN);
+    
+    assert(foundLog.test_run_id === testRunId, 'test_run_id should match');
+    assert(foundLog.message === 'E2E test log with addOtelContext enabled but no active span', 'message should match');
+    assert(foundLog.test_type === 'no-otel-context', 'test_type should match');
+  });
+});


### PR DESCRIPTION
## Description 
solves: #139 

- Add null checks for `span.resource.attributes` in `_addOpentelemetryContext()`.
- Add try catch block in `_addOpentelemetryContext()`.
- Add `addOtelContex` to `ILoggerOptions` Typescript definition.
- Added e2e tests
## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [x] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
